### PR TITLE
#7 #8 optional exp date and duration literals

### DIFF
--- a/cmd/createLab.go
+++ b/cmd/createLab.go
@@ -36,7 +36,7 @@ var createLabCmd = &cobra.Command{
 }
 
 func createLab(cmd *cobra.Command, args []string) {
-	lab.Conf(LabFPath)
+	lab.LoadConf(LabFPath)
 
 	lab.Reason = nuxReason // change reason field to nuxctl
 

--- a/cmd/createLab.go
+++ b/cmd/createLab.go
@@ -49,12 +49,8 @@ func createLab(cmd *cobra.Command, args []string) {
 
 	lab.Reason = nuxReason // change reason field to nuxctl
 
-	// if expiration date is omitted
-	if lab.Expires.IsZero() {
-		fmt.Println(labDuration)
-		d := parseDuration(labDuration)
-		lab.Expires = time.Now().Add(d)
-	}
+	d := parseDuration(labDuration)
+	lab.Expires = time.Now().Add(d)
 
 	j, err := json.Marshal(lab)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import "github.com/nuagenetworks/nuxctl/cmd"
 
 func main() {
 	var (
-		Version = "0.5.1"
+		Version = "0.6.0"
 	)
 	cmd.Execute(Version)
 }

--- a/nuagex/lab.go
+++ b/nuagex/lab.go
@@ -36,20 +36,20 @@ type LabResponse struct {
 	Status   string
 }
 
-// Conf loads nuagex lab configuration from a YAML file
-func (c *Lab) Conf(fn string) *Lab {
+// LoadConf loads nuagex lab configuration from a YAML file
+func (l *Lab) LoadConf(fn string) *Lab {
 	fmt.Printf("Loading lab configuration from '%s' file\n", fn)
 	yamlFile, err := ioutil.ReadFile(fn)
 	if err != nil {
 		log.Printf("Lab Configuration Load error   #%v ", err)
 		os.Exit(1)
 	}
-	err = yaml.Unmarshal(yamlFile, c)
+	err = yaml.Unmarshal(yamlFile, l)
 	if err != nil {
 		log.Fatalf("Unmarshal: %v", err)
 	}
 
-	return c
+	return l
 }
 
 // CreateLab : Create a Lab in NuageX


### PR DESCRIPTION
In this PR two features have been added 

1. optional expiration date
`expires` filed is no longer needed to be present in the lab template file. The lab duration will be computed during the deployment request and by default will be 14 days. Even when the template has the expiration date set in the template file it will be overwritten with the default or user-defined duration.

2. lab duration passed as a tokenized string
A user can specify the duration of a lab if the default 14 days is not enough/not needed. The `-d` argument of the `create-lab` command will handle that.

For instance, if a user needs to create a lab for 5 days the command would look as follows:

```
nuxctl create-lab -l template.yml -d 5d
```

a set of literals is used to configure the duration of a lab:

* `M` - months
* `w` - weeks
* `d` - days
* `h` - hours

a user can combined the tokens and construct the duration string. Examples:

* `1w` - 1 week
* `1w4h` - 1 week and 4 hours
* `5h` - 5 hours
* `1M3w4d` - 1 month, 3 weeks, 4 days


fixes #7 and #8 